### PR TITLE
Silence all extra output from tests

### DIFF
--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -68,14 +68,14 @@ end
 
 When("I create a branch with some commits in the main project") do
   cd @main_repo do
-    `git checkout -b unrelated-branch`
+    `git checkout -q -b unrelated-branch`
     write_file "another_main_file", "stuff"
     `git add -A`
     `git commit -am "Working"`
     write_file "yet_another", "more stuff"
     `git add -A`
     `git commit -am "More working"`
-    `git checkout master`
+    `git checkout -q master`
   end
 end
 

--- a/lib/subrepo/cli.rb
+++ b/lib/subrepo/cli.rb
@@ -36,9 +36,7 @@ module Subrepo
         cmd.flag [:remote, :r], arg_name: "url"
         cmd.flag [:branch, :b], arg_name: "branch"
         cmd.flag [:method, :M]
-        cmd.action do |_, options, args|
-          command_init args.shift, **options.slice(:remote, :branch, :method)
-        end
+        cmd.action(&method(:run_init_command))
       end
     end
 
@@ -129,6 +127,11 @@ module Subrepo
       command :clean do |cmd|
         cmd.action(&method(:run_clean_command))
       end
+    end
+
+    def run_init_command(global_options, options, args)
+      Runner.new(**global_options.slice(:quiet))
+        .init(args[0], **options.slice(:remote, :branch, :method))
     end
 
     def run_clone_command(global_options, options, args)

--- a/lib/subrepo/cli.rb
+++ b/lib/subrepo/cli.rb
@@ -84,10 +84,7 @@ module Subrepo
         cmd.flag [:remote, :r], arg_name: "url"
         cmd.flag [:branch, :b], arg_name: "branch"
         cmd.switch :force, default_value: false
-        cmd.action do |_, options, args|
-          command_push(args.shift, remote: options[:remote], branch: options[:branch],
-                       force: options[:force])
-        end
+        cmd.action(&method(:run_push_command))
       end
     end
 
@@ -143,6 +140,12 @@ module Subrepo
       Runner.new(**global_options.slice(:quiet))
         .pull(args.shift,
               **options.slice(:squash, :remote, :branch, :message, :edit, :update))
+    end
+
+    def run_push_command(global_options, options, args)
+      Runner.new(**global_options.slice(:quiet))
+        .push(args.shift,
+              **options.slice(:remote, :branch, :force))
     end
 
     def run_clean_command(global_options, options, args)

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-require "tempfile"
+require "open3"
 require "rugged"
+require "tempfile"
+
 require "subrepo/version"
 require "subrepo/config"
 require "subrepo/runner"
@@ -98,7 +100,8 @@ module Subrepo
         " --rebase-merges" \
         " -X subtree=#{subdir}"
 
-      system command or raise "Command failed"
+      _out, _err, status = Open3.capture3 command
+      status == 0 or raise "Command failed"
 
       rebased_head = `git rev-parse HEAD`.chomp
       system "git checkout -q #{current_branch}" or raise "Command failed"

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -266,7 +266,9 @@ module Subrepo
       if remote_commit.empty?
         return false
       end
-      system "git fetch -q --no-tags \"#{remote}\" \"#{branch}\"" or raise "Command failed"
+      command = "git fetch -q --no-tags \"#{remote}\" \"#{branch}\""
+      _out, _err, status = Open3.capture3 command
+      status == 0 or raise "Command failed"
       new_commit = `git rev-parse FETCH_HEAD`.chomp
       refs_subrepo_fetch = "refs/subrepo/#{subdir}/fetch"
       system "git update-ref #{refs_subrepo_fetch} #{new_commit}" or raise "Command failed"

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -173,9 +173,9 @@ module Subrepo
 
       repo.branches.create split_branch_name, last_commit
       if force
-        system "git push --force \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+        system "git push -q --force \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
       else
-        system "git push \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+        system "git push -q \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
       end
       pushed_commit = last_commit
 

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -194,36 +194,7 @@ module Subrepo
     end
 
     def command_init(subdir, remote: nil, branch: nil, method: nil)
-      branch ||= "master"
-      remote ||= "none"
-      method ||= "merge"
-      subdir or raise "No subdir provided"
-
-      repo = Rugged::Repository.new(".")
-
-      File.exist? subdir or raise "The subdir '#{subdir} does not exist."
-      config = Config.new(subdir)
-      config_name = config.file_name
-      File.exist? config_name and
-        raise "The subdir '#{subdir}' is already a subrepo."
-      last_subdir_commit = `git log -n 1 --pretty=format:%H -- "#{subdir}"`.chomp
-      last_subdir_commit.empty? and
-        raise "The subdir '#{subdir}' is not part of this repo."
-
-      config.create(remote, branch, method)
-
-      index = repo.index
-      index.add config_name
-      index.write
-      Rugged::Commit.create(repo, tree: index.write_tree,
-                            message: "Initialize subrepo #{subdir}",
-                            parents: [repo.head.target], update_ref: "HEAD")
-
-      if remote == "none"
-        puts "Subrepo created from '#{subdir}' (with no remote)."
-      else
-        puts "Subrepo created from '#{subdir}' with remote '#{remote}' (#{branch})."
-      end
+      Runner.new.init(subdir, remote: remote, branch: branch, method: method)
     end
 
     def command_clone(remote, subdir=nil, branch: nil, method: nil)

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -101,20 +101,19 @@ module Subrepo
         " -X subtree=#{subdir}"
 
       rebased_head = `git rev-parse HEAD`.chomp
-      system "git checkout -q #{current_branch}" or raise "Command failed"
-      system "git merge #{rebased_head} --no-ff --no-edit -q" or
-        raise "Command failed"
+      run_command "git checkout -q #{current_branch}"
+      run_command "git merge #{rebased_head} --no-ff --no-edit -q"
 
       if squash
-        system "git reset --soft #{last_local_commit}" or raise "Command failed"
-        system "git commit -q -m WIP" or raise "Command failed"
+        run_command "git reset --soft #{last_local_commit}"
+        run_command "git commit -q -m WIP"
         config.parent = last_config_commit
       else
         config.parent = rebased_head
       end
 
       config.commit = last_fetched_commit
-      system "git add \"#{config_name}\"" or raise "Command failed"
+      run_command "git add \"#{config_name}\""
 
       message ||=
         "Subrepo-merge #{subdir}/#{branch} into #{current_branch}\n\n" \
@@ -122,9 +121,9 @@ module Subrepo
 
       command = "git commit -q -m \"#{message}\" --amend" 
       if edit
-        system "#{command} --edit" or raise "Command failed"
+        run_command "#{command} --edit"
       else
-        system command or raise "Command failed"
+        run_command command
       end
     end
 
@@ -215,14 +214,14 @@ module Subrepo
             target_diff = target_parent_tree.diff rewritten_tree
             target_patch = target_diff.patch
             if rewritten_patch != target_patch
-              system "git checkout -q #{first_target_parent.oid}" or raise "Command failed"
+              run_command "git checkout -q #{first_target_parent.oid}"
               patch = Tempfile.new("subrepo-patch")
               patch.write rewritten_patch
               patch.close
-              system "git apply --3way #{patch.path}" or raise "Command failed"
+              run_command "git apply --3way #{patch.path}"
               patch.unlink
               target_tree = `git write-tree`.chomp
-              system "git reset -q --hard" or raise "Command failed"
+              run_command "git reset -q --hard"
             end
           end
         end
@@ -266,7 +265,7 @@ module Subrepo
       run_command "git fetch -q --no-tags \"#{remote}\" \"#{branch}\""
       new_commit = `git rev-parse FETCH_HEAD`.chomp
       refs_subrepo_fetch = "refs/subrepo/#{subdir}/fetch"
-      system "git update-ref #{refs_subrepo_fetch} #{new_commit}" or raise "Command failed"
+      run_command "git update-ref #{refs_subrepo_fetch} #{new_commit}"
       new_commit
     end
 

--- a/lib/subrepo/commands.rb
+++ b/lib/subrepo/commands.rb
@@ -95,13 +95,10 @@ module Subrepo
         raise "Last merged commit #{last_merged_commit} not found in fetched commits"
       end
 
-      command = "git rebase" \
+      run_command "git rebase" \
         " --onto #{last_config_commit} #{last_merged_commit} #{last_fetched_commit}" \
         " --rebase-merges" \
         " -X subtree=#{subdir}"
-
-      _out, _err, status = Open3.capture3 command
-      status == 0 or raise "Command failed"
 
       rebased_head = `git rev-parse HEAD`.chomp
       system "git checkout -q #{current_branch}" or raise "Command failed"
@@ -266,13 +263,16 @@ module Subrepo
       if remote_commit.empty?
         return false
       end
-      command = "git fetch -q --no-tags \"#{remote}\" \"#{branch}\""
-      _out, _err, status = Open3.capture3 command
-      status == 0 or raise "Command failed"
+      run_command "git fetch -q --no-tags \"#{remote}\" \"#{branch}\""
       new_commit = `git rev-parse FETCH_HEAD`.chomp
       refs_subrepo_fetch = "refs/subrepo/#{subdir}/fetch"
       system "git update-ref #{refs_subrepo_fetch} #{new_commit}" or raise "Command failed"
       new_commit
+    end
+
+    def run_command(command)
+      _out, _err, status = Open3.capture3 command
+      status == 0 or raise "Command failed"
     end
   end
 end

--- a/lib/subrepo/runner.rb
+++ b/lib/subrepo/runner.rb
@@ -107,22 +107,22 @@ module Subrepo
 
       repo.branches.create split_branch_name, last_commit
       if force
-        system "git push -q --force \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+        run_command "git push -q --force \"#{remote}\" #{split_branch_name}:#{branch}"
       else
-        system "git push -q \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+        run_command "git push -q \"#{remote}\" #{split_branch_name}:#{branch}"
       end
       pushed_commit = last_commit
 
-      system "git checkout -q #{current_branch_name}" or raise "Command failed"
-      system "git reset -q --hard" or raise "Command failed"
-      system "git branch -q -D #{split_branch_name}" or raise "Command failed"
+      run_command "git checkout -q #{current_branch_name}"
+      run_command "git reset -q --hard"
+      run_command "git branch -q -D #{split_branch_name}"
       parent_commit = `git rev-parse HEAD`.chomp
 
       config.remote = remote
       config.commit = pushed_commit
       config.parent = parent_commit
-      system "git add -f -- #{config.file_name}" or raise "Command failed"
-      system "git commit -q -m \"Push subrepo #{subdir}\"" or raise "Command failed"
+      run_command "git add -f -- #{config.file_name}"
+      run_command "git commit -q -m \"Push subrepo #{subdir}\""
 
       puts "Subrepo '#{subdir}' pushed to '#{remote}' (#{branch})." unless quiet
     end
@@ -155,9 +155,9 @@ module Subrepo
           puts "Subrepo '#{subdir}' is up to date." unless quiet
           return
         end
-        system "git rm -r \"#{subdir}\"" or raise "Command failed"
+        run_command "git rm -r \"#{subdir}\""
       end
-      system "git read-tree --prefix=\"#{subdir}\" -u \"#{last_fetched_commit}\"" or raise "Command failed"
+      run_command "git read-tree --prefix=\"#{subdir}\" -u \"#{last_fetched_commit}\""
 
       config_name = config.file_name
       config.create(remote, branch, method)
@@ -172,6 +172,10 @@ module Subrepo
                             parents: [repo.head.target], update_ref: "HEAD")
 
       puts "Subrepo '#{remote}' (#{branch}) cloned into '#{subdir}'." unless quiet
+    end
+
+    def run_command(command)
+      Commands.run_command(command)
     end
   end
 end

--- a/lib/subrepo/runner.rb
+++ b/lib/subrepo/runner.rb
@@ -66,6 +66,67 @@ module Subrepo
       end
     end
 
+    def push(subdir, remote: nil, branch: nil, force: false)
+      subdir or raise "No subdir provided"
+
+      repo = Rugged::Repository.new(".")
+
+      config = Config.new(subdir)
+
+      remote ||= config.remote
+      branch ||= config.branch
+      last_merged_commit = config.commit
+      last_pushed_commit = config.parent
+
+      fetched = Commands.perform_fetch(subdir, remote, branch, last_merged_commit)
+
+      if fetched && !force
+        refs_subrepo_fetch = "refs/subrepo/#{subdir}/fetch"
+        last_fetched_commit = repo.ref(refs_subrepo_fetch).target_id
+        last_fetched_commit == last_merged_commit or
+          raise "There are new changes upstream, you need to pull first."
+      end
+
+      split_branch_name = "subrepo-#{subdir}"
+      if repo.branches.exist? split_branch_name
+        raise "It seems #{split_branch_name} already exists. Remove it first"
+      end
+
+      current_branch_name = `git rev-parse --abbrev-ref HEAD`.chomp
+
+      last_commit = Commands.map_commits(repo, subdir, last_pushed_commit, last_merged_commit)
+
+      unless last_commit
+        if fetched
+          puts "Subrepo '#{subdir}' has no new commits to push." unless quiet
+        else
+          warn "Nothing mapped"
+        end
+        return
+      end
+
+      repo.branches.create split_branch_name, last_commit
+      if force
+        system "git push -q --force \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+      else
+        system "git push -q \"#{remote}\" #{split_branch_name}:#{branch}" or raise "Command failed"
+      end
+      pushed_commit = last_commit
+
+      system "git checkout -q #{current_branch_name}" or raise "Command failed"
+      system "git reset -q --hard" or raise "Command failed"
+      system "git branch -q -D #{split_branch_name}" or raise "Command failed"
+      parent_commit = `git rev-parse HEAD`.chomp
+
+      config.remote = remote
+      config.commit = pushed_commit
+      config.parent = parent_commit
+      system "git add -f -- #{config.file_name}" or raise "Command failed"
+      system "git commit -q -m \"Push subrepo #{subdir}\"" or raise "Command failed"
+
+      puts "Subrepo '#{subdir}' pushed to '#{remote}' (#{branch})." unless quiet
+    end
+
     def clone(remote, subdir=nil, branch: nil, method: nil, force: false)
       remote or raise "No remote provided"
       subdir ||= remote.sub(/\.git$/, "").sub(%r{/$}, "").sub(%r{.*/}, "")


### PR DESCRIPTION
This makes the init and push subcommands honor the `--quiet` option, and silences output from running git commands.