### PR TITLE
Rewrite merge subcommand

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,7 +7,7 @@
 # versions of RuboCop, may require this file to be generated again.
 
 Metrics/AbcSize:
-  Max: 46
+  Max: 81
 
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
@@ -16,14 +16,14 @@ Metrics/BlockLength:
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 273
+  Max: 325
 
 Metrics/CyclomaticComplexity:
   Max: 10
 
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 37
+  Max: 60
 
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -201,9 +201,6 @@ module Subrepo
       walker.push repo.head.target_id
       if last_pushed_commit
         walker.hide last_pushed_commit
-        commit_map = full_commit_map
-      else
-        commit_map = {}
       end
 
       commits = walker.to_a
@@ -211,16 +208,16 @@ module Subrepo
       last_commit = nil
 
       commits.reverse_each do |commit|
-        mapped_commit = map_commit(commit, commit_map)
+        mapped_commit = map_commit(commit)
         last_commit = mapped_commit if mapped_commit
       end
 
       last_commit
     end
 
-    def map_commit(commit, commit_map)
-      target_parents = calculate_target_parents(commit, commit_map)
-      target_tree = calculate_target_tree(commit, target_parents, commit_map) or return
+    def map_commit(commit)
+      target_parents = calculate_target_parents(commit)
+      target_tree = calculate_target_tree(commit, target_parents) or return
 
       # Check if there were relevant changes
       if last_merged_commit
@@ -242,7 +239,7 @@ module Subrepo
       new_commit_sha
     end
 
-    def calculate_target_parents(commit, commit_map)
+    def calculate_target_parents(commit)
       parents = commit.parents
 
       # Map parent commits
@@ -257,7 +254,7 @@ module Subrepo
       target_parent_shas.map { |sha| repo.lookup sha }
     end
 
-    def calculate_target_tree(commit, target_parents, commit_map)
+    def calculate_target_tree(commit, target_parents)
       parents = commit.parents
       rewritten_tree = calculate_subtree(commit)
 
@@ -315,6 +312,10 @@ module Subrepo
     def config_file_in_tree(tree)
       subtree = tree_in_subrepo(tree)
       subtree[".gitrepo"] if subtree
+    end
+
+    def commit_map
+      @commit_map ||= full_commit_map
     end
 
     def full_commit_map

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -27,7 +27,7 @@ module Subrepo
     end
 
     def last_fetched_commit
-      repo.ref(fetch_ref).target_id
+      @last_fetched_commit ||= repo.ref(fetch_ref).target_id
     end
 
     def split_branch_name

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -91,8 +91,7 @@ module Subrepo
         options[:message] = "WIP"
         new_commit_sha = Rugged::Commit.create(repo, options)
 
-        run_command "git checkout -q #{current_branch}"
-        run_command "git reset --hard #{new_commit_sha}"
+        run_command "git merge --ff-only #{new_commit_sha}"
         config.parent = last_config_commit
       else
         run_command "git rebase" \


### PR DESCRIPTION
This accomplishes a few things:
* No longer depend on git rebase, giving more control over the process
* Perform any actual conflict resolution in a separate worktree
* Match behavior of git-subrepo more