### PR TITLE
Be more careful when skipping commits during mapping

### DIFF
--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -114,6 +114,20 @@ When "I resolve the merge conflict with merged content" do
   end
 end
 
+When "I resolve the merge conflict with local content" do
+  expect(@error).not_to be_nil
+  cd @main_repo do
+    cd ".git/tmp/subrepo/#{@subrepo}" do
+      status = `git status --porcelain`.chomp
+      expect(status).to start_with "UU "
+      file = status[3..-1]
+      `git checkout -q --ours #{file}`
+      `git add #{file}`
+      `git commit --no-edit`
+    end
+  end
+end
+
 Then "the subrepo and the remote should have the same contents" do
   repo = Rugged::Repository.new expand_path(@remote)
   tree = repo.head.target.tree

--- a/features/subrepo_commit.feature
+++ b/features/subrepo_commit.feature
@@ -7,11 +7,20 @@ Feature: Commiting merge conflict resolutions in a subrepo
     And I have initialized the subrepo "bar" with that remote
     And I have pushed the subrepo "bar"
 
-  Scenario: Pulling conflicting updates from the remote
+  Scenario: Resolving conflicting update from the remote with merged content
     Given I have updated and committed "a_file" in the remote
     And I have updated and committed "a_file" in the subrepo
     When I attempt to pull the subrepo
     And I resolve the merge conflict with merged content
+    And I finalize the pull using the subrepo commit subcommand
+    And I push the subrepo
+    Then the subrepo and the remote should have the same contents
+
+  Scenario: Resolving conflicting update from the remote with local content
+    Given I have updated and committed "a_file" in the remote
+    And I have updated and committed "a_file" in the subrepo
+    When I attempt to pull the subrepo
+    And I resolve the merge conflict with local content
     And I finalize the pull using the subrepo commit subcommand
     And I push the subrepo
     Then the subrepo and the remote should have the same contents


### PR DESCRIPTION
Don't skip commits that don't change content if they add some ancestors. This makes pushing after resolving conflict with our content work.