### PR TITLE
Make subrepo status command implementation complete

### DIFF
--- a/features/step_definitions/subrepo_action_steps.rb
+++ b/features/step_definitions/subrepo_action_steps.rb
@@ -33,6 +33,24 @@ When "I push the subrepo" do
   end
 end
 
+When "I get the status of the subrepo {string}" do |subrepo|
+  cd @main_repo do
+    run_subrepo_command :status, subrepo
+  end
+end
+
+When "I get the status of all subrepos recursively" do
+  cd @main_repo do
+    run_subrepo_command :status, all_recursive: true
+  end
+end
+
+When "I get the status of all subrepos" do
+  cd @main_repo do
+    run_subrepo_command :status, all: true
+  end
+end
+
 When "I pull the subrepo with squashing( again)" do
   cd @main_repo do
     run_subrepo_command :pull, @subrepo, squash: true
@@ -66,7 +84,7 @@ When "I fetch new commits for the subrepo from the remote" do
   end
 end
 
-When "I clone into {string} from the remote {string} with branch {string}" \
+When "I (have )clone(d) into {string} from the remote {string} with branch {string}" \
   do |subdir, remote, branch|
   cd @main_repo do
     @subrepo = subdir

--- a/features/step_definitions/subrepo_action_steps.rb
+++ b/features/step_definitions/subrepo_action_steps.rb
@@ -88,3 +88,11 @@ When "I attempt to commit( without resolving the conflict)" do
 rescue StandardError => e
   @error = e.message
 end
+
+Then "the subrepo command output should match:" do |string|
+  expect(cli_output.string).to match string
+end
+
+Then "the subrepo command output should equal:" do |string|
+  expect(cli_output.string).to eq string
+end

--- a/features/subrepo_status.feature
+++ b/features/subrepo_status.feature
@@ -1,0 +1,67 @@
+Feature: Status of a subrepo
+
+  Background:
+    Given I have a remote named "bar" with some commits
+    And I have a remote named "barbar" with some commits
+    And I have an existing git project named "foo"
+    And I have cloned into "bar" from the remote "../bar" with branch "master"
+    And I have cloned into "barbar" from the remote "../barbar" with branch "master"
+    And I have cloned into "bar/foobar" from the remote "../barbar" with branch "master"
+
+  Scenario: Getting the status of a single subrepo
+    When I get the status of the subrepo "bar"
+    Then the subrepo command output should match:
+      """
+      Git subrepo 'bar':
+        Remote URL:      \.\./bar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      """
+
+  Scenario: Getting the status of a all subrepos
+    When I get the status of all subrepos
+    Then the subrepo command output should match:
+      """
+      2 subrepos:
+
+      Git subrepo 'bar':
+        Remote URL:      \.\./bar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      Git subrepo 'barbar':
+        Remote URL:      \.\./barbar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      """
+
+  Scenario: Getting the status of a all subrepos recursively
+    When I get the status of all subrepos recursively
+    Then the subrepo command output should match:
+      """
+      3 subrepos:
+
+      Git subrepo 'bar':
+        Remote URL:      \.\./bar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      Git subrepo 'bar/foobar':
+        Remote URL:      \.\./barbar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      Git subrepo 'barbar':
+        Remote URL:      \.\./barbar
+        Tracking Branch: master
+        Pulled Commit:   .......
+        Pull Parent:     .......
+
+      """

--- a/features/support/runner.rb
+++ b/features/support/runner.rb
@@ -15,15 +15,20 @@ module Runner
         ["--#{name}", value.to_s]
       end
     end
-    arguments = ["--quiet", cmd, *args, *flags]
+    arguments = [cmd, *args, *flags]
+    cli_output.rewind
     runner.run arguments
   end
 
   def runner
-    @runner ||= Subrepo::CLI.new.tap do |cli|
+    @runner ||= Subrepo::CLI.new(output: cli_output).tap do |cli|
       cli.setup
       cli.on_error { |ex| raise ex }
     end
+  end
+
+  def cli_output
+    @cli_output ||= StringIO.new
   end
 end
 

--- a/lib/subrepo/cli.rb
+++ b/lib/subrepo/cli.rb
@@ -130,6 +130,7 @@ module Subrepo
 
     def setup_status_command
       desc "Status"
+      arg :subdir, :optional
       command :status do |cmd|
         cmd.switch :all, default_value: false
         cmd.switch :all_recursive, default_value: false

--- a/lib/subrepo/cli.rb
+++ b/lib/subrepo/cli.rb
@@ -12,6 +12,11 @@ module Subrepo
     include GLI::App
     include Subrepo::Commands
 
+    def initialize(output: $stdout)
+      super()
+      @output = output
+    end
+
     def setup
       program_desc "Subrepos -- improved"
 
@@ -171,7 +176,8 @@ module Subrepo
         end
         args.empty? or
           raise "Unknown argument(s) '#{args.join(' ')}' for '#{cmd.name}' command."
-        Dispatcher.new(global_options, options, params).send runner_method
+        Dispatcher.new(global_options, options, params,
+                       output: @output).send runner_method
       end
     end
   end

--- a/lib/subrepo/dispatcher.rb
+++ b/lib/subrepo/dispatcher.rb
@@ -6,10 +6,11 @@ require "subrepo/null_output"
 module Subrepo
   # Dispatch commands from the CLI to the Runner
   class Dispatcher
-    def initialize(global_options, options, args)
+    def initialize(global_options, options, args, output:)
       @global_options = global_options
       @options = options
       @args = args
+      @output = output
     end
 
     def run_init_command
@@ -81,7 +82,7 @@ module Subrepo
           out = if global_options[:quiet]
                   NullOutput.new
                 else
-                  $stdout
+                  @output
                 end
           Runner.new(output: out)
         end

--- a/lib/subrepo/dispatcher.rb
+++ b/lib/subrepo/dispatcher.rb
@@ -29,10 +29,9 @@ module Subrepo
     def run_status_command
       if options[:all_recursive]
         runner.run_status_all(recursive: true)
-      elsif options[:all]
+      elsif options[:all] || !args[0]
         runner.run_status_all
       else
-        args[0] or raise "Command 'status' requires arg 'subdir'."
         runner.run_status(args[0])
       end
     end

--- a/lib/subrepo/dispatcher.rb
+++ b/lib/subrepo/dispatcher.rb
@@ -27,7 +27,14 @@ module Subrepo
     end
 
     def run_status_command
-      runner.run_status(recursive: options[:all_recursive])
+      if options[:all_recursive]
+        runner.run_status_all(recursive: true)
+      elsif options[:all]
+        runner.run_status_all
+      else
+        args[0] or raise "Command 'status' requires arg 'subdir'."
+        runner.run_status(args[0])
+      end
     end
 
     def run_config_command

--- a/lib/subrepo/runner.rb
+++ b/lib/subrepo/runner.rb
@@ -21,13 +21,32 @@ module Subrepo
       main_repository.check_ready
     end
 
-    def run_status(recursive: false)
+    def run_status_all(recursive: false)
       subrepos = main_repository.subrepos(recursive: recursive)
 
-      puts "#{subrepos.count} subrepos:"
-      subrepos.each do |it|
-        puts "Git subrepo '#{it}':"
+      case (count = subrepos.count)
+      when 0
+        puts "No subrepos"
+      when 1
+        puts "1 subrepo:"
+      else
+        puts "#{count} subrepos:"
       end
+
+      subrepos.each do |subdir|
+        puts
+        run_status subdir
+      end
+    end
+
+    def run_status(subdir)
+      subrepo = sub_repository(subdir)
+      config = subrepo.config
+      puts "Git subrepo '#{subdir}':"
+      puts "  Remote URL:      #{config.remote}"
+      puts "  Tracking Branch: #{config.branch}"
+      puts "  Pulled Commit:   #{config.commit[0..6]}"
+      puts "  Pull Parent:     #{config.parent[0..6]}"
     end
 
     def run_config(subdir, option:, value:, force: false)


### PR DESCRIPTION
- Allow specifying a single subrepo to get its status
- Show relevant information per subrepo instead of just the name
- Add facility to test subrepo command output in cucumber scenarios