### PR TITLE
Improve commit mapping

### DIFF
--- a/features/push_after_pull.feature
+++ b/features/push_after_pull.feature
@@ -139,6 +139,7 @@ Feature: Pushing after pulling
     And the commit map should equal:
       """
       Push subrepo bar                     -> Subrepo-merge bar/master into master
+      Add bar/other_file in repo foo       -> Add bar/other_file in repo foo
       Subrepo-merge bar/master into master -> Subrepo-merge bar/master into master
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo

--- a/lib/subrepo/commit_mapper.rb
+++ b/lib/subrepo/commit_mapper.rb
@@ -52,8 +52,7 @@ module Subrepo
     def map_dependent_commits(pushed_commit_oid, merged_commit_oid, remote_commit_tree)
       sub_walker = Rugged::Walker.new(repo)
       sub_walker.push pushed_commit_oid
-      # TODO: Maybe make sure we don't hide pushed_commit_oid
-      @mapping.each_key { |oid| sub_walker.hide oid }
+      @mapping.each_key { |oid| sub_walker.hide oid unless oid == pushed_commit_oid }
 
       dependent_commits = sub_walker.to_a
 

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -391,7 +391,7 @@ module Subrepo
       parents = commit.parents
       rewritten_tree = calculate_subtree(commit)
 
-      if parents.empty?
+      if target_parents.empty?
         return rewritten_tree.entries.empty? ? nil : rewritten_tree
       end
 
@@ -400,8 +400,6 @@ module Subrepo
       end
 
       first_target_parent = target_parents.first
-
-      return rewritten_tree unless first_target_parent
 
       # If there is only one target parent, and at least one of the orignal
       # parents has the same subtree as the current commit, then this would

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -377,8 +377,7 @@ module Subrepo
 
       # Map parent commits
       target_parent_shas = parents.map do |parent|
-        # TODO: Improve upon last_merged_commit as best guess
-        commit_map[parent.oid] || last_merged_commit
+        commit_map[parent.oid]
       end.uniq.compact
       if (mapped_oid = commit_map[commit.oid])
         target_parent_shas << mapped_oid unless target_parent_shas.include? mapped_oid

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -380,8 +380,7 @@ module Subrepo
         # TODO: Improve upon last_merged_commit as best guess
         commit_map[parent.oid] || last_merged_commit
       end.uniq.compact
-      if commit_map[commit.oid]
-        mapped_oid = commit_map[commit.oid]
+      if (mapped_oid = commit_map[commit.oid])
         target_parent_shas << mapped_oid unless target_parent_shas.include? mapped_oid
       end
       target_parent_shas.map { |sha| repo.lookup sha }


### PR DESCRIPTION
Part of a process of making commit mapping more precise by disallowing guessing and unmapped commits.