### PR TITLE
Improve commit mapping for commits before subrepo creation

### DIFF
--- a/features/complex_pull.feature
+++ b/features/complex_pull.feature
@@ -19,6 +19,7 @@ Feature: Complex pull
       Add quuz                             -> Add quuz
       Add baz                              -> Add baz
       Clone remote ../bar into bar         -> Add other_file
+      Initial commit                       -> 
       """
 
   Scenario: Squash-pulling before and after changes with intermediate branch points

--- a/features/complex_push.feature
+++ b/features/complex_push.feature
@@ -49,6 +49,7 @@ Feature: Complex push
       Update zyxxy                         -> Add other_file
       Add zyxxy                            -> Add other_file
       Clone remote ../bar into bar         -> Add other_file
+      Initial commit                       -> 
       """
     And the remote's log should equal:
       """

--- a/features/pull_after_clone.feature
+++ b/features/pull_after_clone.feature
@@ -21,6 +21,7 @@ Feature: Pull after clone
       Subrepo-merge bar/master into master -> Add foobar
       Add foobar                           -> Add foobar
       Clone remote ../bar into bar         -> Add other_file
+      Initial commit                       -> 
       """
     And the remote's log should equal:
       """

--- a/features/push_after_pull.feature
+++ b/features/push_after_pull.feature
@@ -35,6 +35,7 @@ Feature: Pushing after pulling
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo           -> Add bar/a_file in repo foo
+      Initial commit                       -> 
       """
 
   Scenario: Pushing older commits after pulling
@@ -144,6 +145,7 @@ Feature: Pushing after pulling
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo           -> Add bar/a_file in repo foo
+      Initial commit                       -> 
       """
 
   Scenario: Pushing newer commits after pulling with squashing

--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -130,6 +130,10 @@ When "I merge the branch for {string} in the remote" do |file|
   merge_branch(full_remote, branch_name)
 end
 
+When "I (have )commit(ted) a new file {string}" do |file|
+  create_and_commit_file(@main_repo, file)
+end
+
 When "I (have )commit(ted) a new file {string} in subdirectory {string}" do |file, subdir|
   create_and_commit_file_in_subdir(@main_repo, subdir: subdir, file: file)
 end

--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -219,7 +219,7 @@ Then "the commit map should equal:" do |string|
     commit_map = Subrepo::CommitMapper.map_commits(sub)
     repo = main.repo
     named_map = commit_map.map do |from, to|
-      [repo.lookup(from).summary, repo.lookup(to).summary]
+      [repo.lookup(from).summary, to && repo.lookup(to).summary]
     end
     width = named_map.map(&:first).map(&:length).max
     result = named_map.map do |from, to|

--- a/features/subrepo_clone.feature
+++ b/features/subrepo_clone.feature
@@ -16,3 +16,27 @@ Feature: Cloning a subrepo
       * Initial commit
       """
     And the subrepo configuration should contain the latest commit and parent
+
+  Scenario: Cloning a remote as a subrepo after multiple commits
+    Given I have a remote named "barbar" with some commits
+    And I have an existing git project named "foo"
+    And I have committed a new file "baz"
+    When I clone into "bar" from the remote "../barbar" with branch "master"
+    Then the subrepo and the remote should have the same contents
+    And the remote's log should equal:
+      """
+      * Add other_file
+      * Add this_file
+      """
+    And the project's log should equal:
+      """
+      * Clone remote ../barbar into bar
+      * Add baz in repo foo
+      * Initial commit
+      """
+    And the commit map should equal:
+      """
+      Clone remote ../barbar into bar -> Add other_file
+      Add baz in repo foo             -> 
+      Initial commit                  -> 
+      """

--- a/features/subrepo_pull.feature
+++ b/features/subrepo_pull.feature
@@ -31,6 +31,7 @@ Feature: Pulling a subrepo
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo           -> Add bar/a_file in repo foo
+      Initial commit                       -> 
       """
     And the subrepo branch has been removed
 
@@ -58,6 +59,7 @@ Feature: Pulling a subrepo
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo           -> Add bar/a_file in repo foo
+      Initial commit                       -> 
       """
 
   Scenario: Pulling updates from the remote
@@ -88,6 +90,7 @@ Feature: Pulling a subrepo
       Push subrepo bar                     -> Add bar/a_file in repo foo
       Initialize subrepo bar               -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo           -> Add bar/a_file in repo foo
+      Initial commit                       -> 
       """
 
   Scenario: Pulling after committing to the main repo
@@ -117,6 +120,7 @@ Feature: Pulling a subrepo
       Push subrepo bar               -> Add bar/a_file in repo foo
       Initialize subrepo bar         -> Add bar/a_file in repo foo
       Add bar/a_file in repo foo     -> Add bar/a_file in repo foo
+      Initial commit                 -> 
       """
 
   Scenario: Pulling twice in a row has no extra effect

--- a/features/support/repo.rb
+++ b/features/support/repo.rb
@@ -27,6 +27,26 @@ module Repo
     end
   end
 
+  def create_and_commit_file(proj, file)
+    cd proj do
+      repo = Rugged::Repository.new(".")
+      write_file file, "stuff"
+      index = repo.index
+      index.add file
+      index.write
+      parents = if repo.head_unborn?
+                  []
+                else
+                  [repo.head.target]
+                end
+      Rugged::Commit.create(repo,
+                            tree: index.write_tree,
+                            message: "Add #{file} in repo #{proj}",
+                            parents: parents,
+                            update_ref: "HEAD")
+    end
+  end
+
   def create_and_commit_file_in_subdir(proj, subdir:, file: "a_file")
     cd proj do
       repo = Rugged::Repository.new(".")

--- a/lib/subrepo/commit_mapper.rb
+++ b/lib/subrepo/commit_mapper.rb
@@ -74,8 +74,9 @@ module Subrepo
         # Compare trees for earlier commits with their mapped parents' trees,
         # and with their mapped parents' children's trees
         sub_commit.parents.each do |sub_parent|
+          next unless @mapping.key? sub_parent.oid
+
           mapped_parent_oid = @mapping[sub_parent.oid]
-          next unless mapped_parent_oid
 
           remote_children = remote_child_map[mapped_parent_oid] || []
           mapped = remote_children.find do |remote_child|

--- a/lib/subrepo/commit_mapper.rb
+++ b/lib/subrepo/commit_mapper.rb
@@ -59,6 +59,11 @@ module Subrepo
       dependent_commits.reverse_each do |sub_commit|
         sub_commit_tree = subrepo.calculate_subtree(sub_commit)
 
+        if sub_commit.parents.empty? && sub_commit_tree.entries.empty?
+          @mapping[sub_commit.oid] = nil
+          next
+        end
+
         # TODO: Maybe this section only makes sense for the first commit we handle?
         # Compare trees for earlier commits with the current tree
         if sub_commit_tree.oid == remote_commit_tree.oid

--- a/lib/subrepo/commit_mapper.rb
+++ b/lib/subrepo/commit_mapper.rb
@@ -51,6 +51,7 @@ module Subrepo
 
     def map_dependent_commits(pushed_commit_oid, merged_commit_oid, remote_commit_tree)
       sub_walker = Rugged::Walker.new(repo)
+      sub_walker.sorting(Rugged::SORT_TOPO)
       sub_walker.push pushed_commit_oid
       @mapping.each_key { |oid| sub_walker.hide oid unless oid == pushed_commit_oid }
 

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -173,6 +173,7 @@ module Subrepo
 
     def validate_last_merged_commit_present_in_fetched_commits
       walker = Rugged::Walker.new(repo)
+      walker.sorting(Rugged::SORT_TOPO)
       walker.push last_fetched_commit
       found = walker.to_a.any? { |commit| commit.oid == last_merged_commit }
       unless found
@@ -227,6 +228,7 @@ module Subrepo
       @local_commits ||=
         begin
           walker = Rugged::Walker.new(repo)
+          walker.sorting(Rugged::SORT_TOPO)
           walker.push repo.head.target_id
           walker.to_a
         end
@@ -236,6 +238,7 @@ module Subrepo
       @remote_commits ||=
         begin
           walker = Rugged::Walker.new(repo)
+          walker.sorting(Rugged::SORT_TOPO)
           walker.push last_merged_commit
           walker.to_a
         end
@@ -287,6 +290,7 @@ module Subrepo
       create_worktree_if_needed
 
       walker = Rugged::Walker.new(repo)
+      walker.sorting(Rugged::SORT_TOPO)
       walker.push repo.head.target_id
       walker.hide last_pushed_commit if last_pushed_commit
 
@@ -349,6 +353,7 @@ module Subrepo
 
     def reverse_map_commits(inverse_map, split_branch_commit)
       walker = Rugged::Walker.new(repo)
+      walker.sorting(Rugged::SORT_TOPO)
       walker.push split_branch_commit.oid
       walker.hide split_branch_commit.parents.first.oid
 

--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -304,7 +304,12 @@ module Subrepo
 
     def map_commit(commit)
       target_parents = calculate_target_parents(commit)
-      target_tree = calculate_target_tree(commit, target_parents) or return
+      target_tree = calculate_target_tree(commit, target_parents)
+
+      unless target_tree
+        commit_map[commit.oid] ||= nil
+        return
+      end
 
       # Skip trivial subrepo merge commits: Tree does not change
       # from last merged commit, last merged commit is one of
@@ -377,7 +382,7 @@ module Subrepo
 
       # Map parent commits
       target_parent_shas = parents.map do |parent|
-        commit_map[parent.oid]
+        commit_map.fetch(parent.oid)
       end.uniq.compact
       if (mapped_oid = commit_map[commit.oid])
         target_parent_shas << mapped_oid unless target_parent_shas.include? mapped_oid


### PR DESCRIPTION
- Do not allow unmapped commits
- Explicitly map all commits from before the creation of the subrepo's directory (to `nil`)
- Always use topological ordering when walking commits