### PR TITLE
Update cucumber tests for changed git output

### DIFF
--- a/features/complex_push.feature
+++ b/features/complex_push.feature
@@ -20,13 +20,13 @@ Feature: Complex push
       |\  
       | * Add foobar
       * | Add bar/smurf in repo foo
-      * |   Merge branch 'subrepo-branch'
+      * |   Merge branch 'subrepo-branch' into master
       |\ \  
       | |/  
       |/|   
       | * Update bar/barfoo in repo foo
       | * Add bar/barfoo in repo foo
-      * |   Merge branch 'unrelated-branch'
+      * |   Merge branch 'unrelated-branch' into master
       |\ \  
       | |/  
       |/|   
@@ -38,18 +38,18 @@ Feature: Complex push
       """
     And the commit map should equal:
       """
-      Push subrepo bar                     -> Subrepo-merge bar/master into master
-      Subrepo-merge bar/master into master -> Subrepo-merge bar/master into master
-      Add bar/smurf in repo foo            -> Add bar/smurf in repo foo
-      Merge branch 'subrepo-branch'        -> Merge branch 'subrepo-branch'
-      Update bar/barfoo in repo foo        -> Update bar/barfoo in repo foo
-      Add bar/barfoo in repo foo           -> Add bar/barfoo in repo foo
-      Add foobar                           -> Add foobar
-      Merge branch 'unrelated-branch'      -> Add other_file
-      Update zyxxy                         -> Add other_file
-      Add zyxxy                            -> Add other_file
-      Clone remote ../bar into bar         -> Add other_file
-      Initial commit                       -> 
+      Push subrepo bar                            -> Subrepo-merge bar/master into master
+      Subrepo-merge bar/master into master        -> Subrepo-merge bar/master into master
+      Add bar/smurf in repo foo                   -> Add bar/smurf in repo foo
+      Merge branch 'subrepo-branch' into master   -> Merge branch 'subrepo-branch' into master
+      Update bar/barfoo in repo foo               -> Update bar/barfoo in repo foo
+      Add bar/barfoo in repo foo                  -> Add bar/barfoo in repo foo
+      Add foobar                                  -> Add foobar
+      Merge branch 'unrelated-branch' into master -> Add other_file
+      Update zyxxy                                -> Add other_file
+      Add zyxxy                                   -> Add other_file
+      Clone remote ../bar into bar                -> Add other_file
+      Initial commit                              -> 
       """
     And the remote's log should equal:
       """
@@ -57,7 +57,7 @@ Feature: Complex push
       |\  
       | * Add foobar
       * | Add bar/smurf in repo foo
-      * |   Merge branch 'subrepo-branch'
+      * |   Merge branch 'subrepo-branch' into master
       |\ \  
       | |/  
       |/|   

--- a/features/step_definitions/repo_steps.rb
+++ b/features/step_definitions/repo_steps.rb
@@ -114,13 +114,19 @@ end
 
 When "I merge in the main project branch" do
   cd @main_repo do
-    `git merge --no-ff unrelated-branch`
+    # NOTE: Explicit message given to ensure uniform result across git
+    # versions. The explicit message can be removed once git 2.28 is commonly
+    # used.
+    `git merge --no-ff unrelated-branch -m "Merge branch 'unrelated-branch' into master"`
   end
 end
 
 When "I merge in the subrepo branch" do
   cd @main_repo do
-    `git merge --no-ff subrepo-branch`
+    # NOTE: Explicit message given to ensure uniform result across git
+    # versions. The explicit message can be removed once git 2.28 is commonly
+    # used.
+    `git merge --no-ff subrepo-branch -m "Merge branch 'subrepo-branch' into master"`
   end
 end
 


### PR DESCRIPTION
Git merge message when merging into master was changed in https://github.com/git/git/commit/489947cee5095b168cbac111ff7bd1eadbbd90dd. This change ensures that the expected messages match the new default message, and, for now, that those same messages are generated on older git versions.