### PR TITLE
Update development infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ require:
   - rubocop-rspec
 
 AllCops:
+  Exclude:
+    - 'vendor/bundle/**/*'
   NewCops: enable
   TargetRubyVersion: 2.5
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
 
@@ -48,10 +49,10 @@ Lint/AmbiguousBlockAssociation:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
-# RSpec describe blocks can be any size
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - 'spec/**/*' # RSpec describe blocks can be any size
+    - '*.gemspec' # Gem spec blocks can be any size
 
 Performance/StartWith:
   AutoCorrect: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
 
+# Make BeginEndAlignment behavior match EndAlignment
+Layout/BeginEndAlignment:
+  EnforcedStyleAlignWith: begin
+
 # Tables are nice
 Layout/HashAlignment:
   EnforcedColonStyle: table

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ dist: bionic
 cache:
   bundler: true
 
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
+script: bundle exec rake
+
+jobs:
+  include:
+    - rvm: 2.5
+    - rvm: 2.6
+    - rvm: 2.7
+    - rvm: 2.7.1
+      name: "RuboCop"
+      script: bundle exec rubocop
 
 branches:
   only:

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,0 +1,17 @@
+lib/subrepo
+lib/subrepo.rb
+lib/subrepo/cli.rb
+lib/subrepo/commands.rb
+lib/subrepo/commit_mapper.rb
+lib/subrepo/config.rb
+lib/subrepo/dispatcher.rb
+lib/subrepo/main_repository.rb
+lib/subrepo/null_output.rb
+lib/subrepo/runner.rb
+lib/subrepo/sub_repository.rb
+lib/subrepo/version.rb
+COPYING
+CODE_OF_CONDUCT.md
+Changelog.md
+README.md
+bin/git-subrepo

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "cucumber/rake/task"
+require "rake/manifest"
 
 RSpec::Core::RakeTask.new(:spec)
 Cucumber::Rake::Task.new(:cucumber) do |t|
@@ -66,5 +67,10 @@ namespace :compat do
     exit 1 unless success
   end
 end
+
+Rake::Manifest::Task.new do |t|
+  t.patterns = ["lib/**/*", "COPYING", "*.md", "bin/*"]
+end
+task build: "manifest:check"
 
 task default: [:spec, :cucumber, "compat:regression"]

--- a/subrepo.gemspec
+++ b/subrepo.gemspec
@@ -1,40 +1,42 @@
 # frozen_string_literal: true
 
-require "rake/file_list"
 require_relative "lib/subrepo/version"
 
-Gem::Specification.new do |s|
-  s.name = "git-subrepo-ng"
-  s.version = Subrepo::VERSION
-  s.summary = "Clone of git subrepo, with improvements"
-  s.authors = ["Matijs van Zuijlen"]
-  s.email = ["matijs@matijs.net"]
-  s.homepage = "https://github.com/mvz/git-subrepo-ng"
+Gem::Specification.new do |spec|
+  spec.name = "git-subrepo-ng"
+  spec.version = Subrepo::VERSION
+  spec.authors = ["Matijs van Zuijlen"]
+  spec.email = ["matijs@matijs.net"]
 
-  s.required_ruby_version = ">= 2.5.0"
+  spec.summary = "Clone of git subrepo, with improvements"
+  spec.homepage = "https://github.com/mvz/git-subrepo-ng"
+  spec.license = "GPL-3.0+"
 
-  s.license = "GPL-3.0+"
+  spec.required_ruby_version = ">= 2.5.0"
 
-  s.metadata["homepage_uri"] = s.homepage
-  s.metadata["source_code_uri"] = "https://github.com/mvz/git-subrepo-ng"
-  s.metadata["changelog_uri"] = "https://github.com/mvz/git-subrepo-ng/blob/master/Changelog.md"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/mvz/git-subrepo-ng"
+  spec.metadata["changelog_uri"] = "https://github.com/mvz/git-subrepo-ng/blob/master/Changelog.md"
 
-  s.files = Rake::FileList["{bin,lib}/**/*", "COPYING"]
-    .exclude(*File.read(".gitignore").split)
-  s.rdoc_options = ["--main", "README.md"]
-  s.extra_rdoc_files = ["Changelog.md", "README.md"]
+  spec.files = File.read("Manifest.txt").split
+  spec.rdoc_options = ["--main", "README.md"]
+  spec.extra_rdoc_files = ["Changelog.md", "README.md"]
+  spec.require_paths = ["lib"]
 
-  s.bindir = "bin"
-  s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir = "bin"
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  s.add_runtime_dependency "gli", "~> 2.5"
-  s.add_runtime_dependency "rugged", "~> 1.0"
+  spec.add_runtime_dependency "gli", "~> 2.5"
+  spec.add_runtime_dependency "rugged", "~> 1.0"
 
-  s.add_development_dependency "aruba", "~> 1.0.0"
-  s.add_development_dependency "pry", "~> 0.13.0"
-  s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "rspec", "~> 3.0"
-  s.add_development_dependency "simplecov", "~> 0.19.0"
-
-  s.require_paths = ["lib"]
+  spec.add_development_dependency "aruba", "~> 1.0.0"
+  spec.add_development_dependency "pry", "~> 0.13.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.1.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 0.92.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.43.0"
+  spec.add_development_dependency "simplecov", "~> 0.19.0"
 end


### PR DESCRIPTION
- Update gemspec structure to match what bundle gem generates
- Use rake-manifest to maintain a list of files to include the gem
- Add rubocop-packaging plugin
- Add rubocop gems as development dependencies
- Configure BeginEndAlignment cop to match EndAlignment
- Run RuboCop on Travis as a separate job
- Configure Dependabot