### PR TITLE
Bump RuboCop and configure LineContinuationLeadingSpace cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,8 +63,8 @@ Lint/AssignmentInCondition:
 
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*' # RSpec describe blocks can be any size
-    - '*.gemspec' # Gem spec blocks can be any size
+    - 'spec/**/*'  # RSpec describe blocks can be any size
+    - '*.gemspec'  # Gem spec blocks can be any size
 
 Performance/StartWith:
   AutoCorrect: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedLastArgumentHashStyle: ignore_implicit
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/subrepo.gemspec
+++ b/subrepo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.9"


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
- Fix yamllint offenses