### PR TITLE
Update RuboCop version and fix new offenses

### DIFF
--- a/lib/subrepo/sub_repository.rb
+++ b/lib/subrepo/sub_repository.rb
@@ -250,8 +250,8 @@ module Subrepo
       @subref ||= subdir
         .gsub(%r{(^|/)\.}, "\\1%2e") # dot at start or after /
         .gsub(%r{\.lock($|/)}, "%2elock\\1") # .lock at end or before /
-        .gsub(/\.\./, "%2e%2e") # pairs of consecutive dots
-        .gsub(/%2e\./, "%2e%2e") # odd numbers of dots
+        .gsub("..", "%2e%2e") # pairs of consecutive dots
+        .gsub("%2e.", "%2e%2e") # odd numbers of dots
         .gsub(/[\000-\037\177]/) { |ch| hexify ch } # ascii control characters
         .gsub(/[ ~^:?*\[\n\\]/) { |ch| hexify ch } # other forbidden characters
         .gsub(%r{//+}, "/") # consecutive slashes

--- a/subrepo.gemspec
+++ b/subrepo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop", "~> 1.54"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.18"
   spec.add_development_dependency "rubocop-rspec", "~> 2.22"


### PR DESCRIPTION
- Bump RuboCop version
- Autocorrect Style/RedundantRegexpArgument
