### PR TITLE
Add explicity dependency on ostruct

### DIFF
--- a/subrepo.gemspec
+++ b/subrepo.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
   spec.add_dependency "gli", "~> 2.5"
+  spec.add_dependency "ostruct", "~> 0.6.0"
   spec.add_dependency "rugged", "~> 1.0"
 
   spec.add_development_dependency "aruba", "~> 2.0"


### PR DESCRIPTION
This will be needed with Ruby 3.5 and in the mean time silences a warning that causes the tests to fail. Ideally, this would be part of the dependencies of gli. Once gli depends on ostruct, the direct dependency can be removed.
